### PR TITLE
Fix transient console + python interpreter issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repo contains scripts to extract game data from GCG files in realtime for l
 - [Features](#features)
 - [Requirements](#requirements)
 - [Running the GUI](#running-the-gui)
+    - [Methods](#methods)
+    - [In the GUI](#in-the-gui)
 - [CLI Usage](#cli-usage)
    - [Default Version](#default-version----one-combined-score-file-std)
    - [Australian Version](#australian-version----two-score-files---ver-au)
@@ -40,6 +42,7 @@ This repo contains scripts to extract game data from GCG files in realtime for l
 ## Running the GUI
 >Running the GUI presumes that you have the TK App installed (Windows & the official macOS python.org installers already include Tk.)
 
+### Methods
 You have two options:
 - UI (**Recommended**)
     - Clone the repo or download the ``watch_gcg.py`` script to your computer
@@ -56,7 +59,13 @@ You have two options:
     # OR
     py watch_gcg.py   # Windows launcher
     ```
+### In the GUI
 
+- Use the dropdown menu at the top to choose between the Default and Australian versions. 
+- Use the ``Browse`` buttons to choose pre-existing files.
+- Press ``Start`` to start watching the ``.gcg`` file.
+
+> Note: **DO NOT** change the ``Python exe`` field and **DO NOT** click on the ``Find`` button unless you specifically want to change the python executable that you're using. This field is pre-populated by the script, which automatically finds your python executable. If you change the field and can't figure out where your python executable lives, close and re-open the GUI using the methods detailed above. 
 
 
 ## CLI Usage

--- a/README.md
+++ b/README.md
@@ -1,24 +1,54 @@
 # WatchGCG
 
-This repo contains scripts to extract game data from GCG files in realtime for live stream broadcasts.
+This repo contains scripts to extract game data from GCG files in realtime for live stream broadcasts. Works as both a **CLI** tool and a **GUI** using the same script.
 
-## Using watch_gcg.py to capture realtime output from a GCG file
+## Features
 
-The watch_gcg.py script requires that you have python3 installed on your computer. You can follow the steps [here](https://kinsta.com/knowledgebase/install-python) to install python3 for your operating system.
+- **Automatic dependency handling**: The script auto-installs required modules (no need to pre-install).
 
-Once python3 is installed, you will need to install the python watchfiles module. This module allows python to "watch" the GCG file you are editing so it can update the output files when it detects the GCG file has changed. Install the module with the following command:
+- **Dual interface**: Run as CLI or GUI
 
-```
-python -m pip install watchfiles
-```
+- **Two output “versions”**:
+   - ``std`` (default): one score file containing both players' scores
+   - ``au``: separate score files for Player 1 and Player 2
 
-Alternatively, your python command might be called 'python3' in which case you would need to run the following command:
+## Requirements
+- Python 3.7+ recommended (any modern Python 3 should work).
 
-```
-python3 -m pip install watchfiles
-```
+- ``watchfiles`` module is **installed automatically** on first run. If you prefer manual install:
 
-Once the watchfiles module is installed, you can now run the watch_gcg.py script. The script needs 6 arguments:
+    ```bash
+    # Manual installation
+    python -m pip install watchfiles
+    # or
+    python3 -m pip install watchfiles
+    # on Windows if you use the launcher:
+    py -m pip install watchfiles
+    ```
+> The script may optionally upgrade ``pip/setuptools/wheel``, but by default it does not (see ``ensure_awatch(upgrade_tools=False)`` in the code).
+
+## Running the GUI
+You have two options:
+- UI (**Recommended**)
+    - Double-click ``watch_gcg.py``
+- CLI
+    - Any **one** of these will open the GUI:
+
+    ```bash
+    python watch_gcg.py
+    # OR
+    python3 watch_gcg.py
+    # OR
+    py watch_gcg.py   # Windows launcher
+    ```
+
+>Running the GUI presumes that you have the TK App installed
+
+## CLI Usage
+
+### Default version -- one combined score file (``std``)
+
+The script needs 6 arguments:
 
 - The input GCG file to watch
 - The input lexicon file with definitions
@@ -29,10 +59,31 @@ Once the watchfiles module is installed, you can now run the watch_gcg.py script
 
 For example, to watch a GCG file called 'test.gcg', use the following command:
 
-```
-python3 watch_gcg.py --gcg test.gcg --lex CSW24defs.csv --score score.txt --unseen unseen.txt --count count.txt --lp lp.txt
+```bash
+python3 watch_gcg.py --gcg test.gcg --lex CSW24defs.csv --score score.txt --unseen unseentiles.txt --count unseencount.txt --lp lastplay.txt
 ```
 
-The script should now run indefinitely watching for changes to the GCG file. To stop execution, hit control-C.
+### Australian version -- two score files (``--ver au``)
 
-The output files will update whenever the GCG file changes, so if you are editing the GCG file in Quackle, it will not write to the output files until you save the game in Quackle.
+To output two separate score files, pass:
+- ``--ver au``, and
+- either one ``--score`` OR **both** ``--p1score`` and ``--p2score``
+
+#### Option A (use ``--score`` only)
+
+```bash
+python3 watch_gcg.py --gcg test.gcg --lex CSW24defs.csv --ver au --score score.txt --unseen unseentiles.txt --count unseencount.txt --lp lastplay.txt
+# writes ./p1_score.txt and ./p2_score.txt
+```
+
+#### Option B (use both ``--p1score`` and ``--p2score``)
+
+```bash
+python3 watch_gcg.py --gcg test.gcg --lex CSW24defs.csv --ver au --p1score p1_score.txt --p2score p2_score.txt --unseen unseentiles.txt --count unseencount.txt --lp lastplay.txt
+
+```
+
+## Notes
+The script should now run indefinitely watching for changes to the GCG file. To stop execution in the terminal (CLI), hit ``Control-C``. In the GUI, close the window.
+
+The output files update when you save the game. Editing/committing moves in Quackle without saving the ``.gcg`` file won’t trigger changes.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,31 @@
 # WatchGCG
 
-This repo contains scripts to extract game data from GCG files in realtime for live stream broadcasts. Works as both a **CLI** tool and a **GUI** using the same script.
+This repo contains scripts to extract game data from GCG files in realtime for live stream broadcasts. Works as both a **GUI** and a **CLI** tool using the same script.
+
+## Table of Contents
+- [Features](#features)
+- [Requirements](#requirements)
+- [Running the GUI](#running-the-gui)
+- [CLI Usage](#cli-usage)
+   - [Default Version](#default-version----one-combined-score-file-std)
+   - [Australian Version](#australian-version----two-score-files---ver-au)
+- [Notes](#notes)
 
 ## Features
 
-- **Automatic dependency handling**: The script auto-installs required modules (no need to pre-install).
+- **Automatic Dependency Handling**: The script auto-installs required modules (no need to pre-install anything).
 
-- **Dual interface**: Run as CLI or GUI
+- **Dual Interface**: The same script can be run as a graphical interface (GUI) or from the command line (CLI).
 
-- **Two output “versions”**:
-   - ``std`` (default): one score file containing both players' scores
-   - ``au``: separate score files for Player 1 and Player 2
+- **Version Selection**: Supports both the default (``std``) and Australian (``au``) versions of the script (choose with the optional ``--ver`` parameter).
+
+   - ``std``: outputs one score file containing both players' scores
+   - ``au``: outputs separate score files for Player 1 and Player 2
 
 ## Requirements
 - Python 3.7+ recommended (any modern Python 3 should work).
 
-- ``watchfiles`` module is **installed automatically** on first run. If you prefer manual install:
+- ``watchfiles`` module is **installed automatically** on first run. If you prefer manual install instead, run:
 
     ```bash
     # Manual installation
@@ -28,10 +38,15 @@ This repo contains scripts to extract game data from GCG files in realtime for l
 > The script may optionally upgrade ``pip/setuptools/wheel``, but by default it does not (see ``ensure_awatch(upgrade_tools=False)`` in the code).
 
 ## Running the GUI
+>Running the GUI presumes that you have the TK App installed (Windows & the official macOS python.org installers already include Tk.)
+
 You have two options:
 - UI (**Recommended**)
+    - Clone the repo or download the ``watch_gcg.py`` script to your computer
     - Double-click ``watch_gcg.py``
 - CLI
+    - Clone the repo or download the ``watch_gcg.py`` script to your computer
+    - Navigate to its directory in the Command Terminal
     - Any **one** of these will open the GUI:
 
     ```bash
@@ -42,7 +57,7 @@ You have two options:
     py watch_gcg.py   # Windows launcher
     ```
 
->Running the GUI presumes that you have the TK App installed
+
 
 ## CLI Usage
 

--- a/watch_gcg.py
+++ b/watch_gcg.py
@@ -528,6 +528,10 @@ def run_gui():
             if self.proc:
                 self.on_log("[warn] Already running.\n")
                 return
+            
+            if not python_exe:
+                python_exe = sys.executable or "py"
+
             self._gcg_display = Path(gcg_path).name if gcg_path else None
             cmd = [python_exe, "-u", script_path] + args
             self.on_log(f"[info] Launching: {' '.join(cmd)}\n")
@@ -605,6 +609,23 @@ def run_gui():
             # Choose upgrade_tools=True to upgrade pip/setuptools/wheel
             ensure_awatch(self._append_log, upgrade_tools=False)
 
+            # Validate python exe
+            py = (self.python_var.get() or "").strip()
+            if not py:
+                py = sys.executable  # fallback
+
+            def _looks_like_python_exe(p):
+                base = os.path.basename(p).lower()
+                return base in ("python.exe", "pythonw.exe", "py.exe", "pyw.exe") or base.startswith("python") and base.endswith(".exe")
+
+            # If user accidentally picked the script or a folder, warn
+            if os.path.isdir(py) or (py.lower().endswith(".py") and os.path.exists(py)) or (os.name == "nt" and not _looks_like_python_exe(py) and py not in ("py", "python", "python3")):
+                messagebox.showwarning(
+                    "Invalid Python",
+                    "The 'Python exe' field must point to a Python interpreter (python.exe) or be 'py'."
+                )
+                return
+            
             # Runner + polling
             self.runner = TailRunner(self._append_log)
             self.after(120, self._poll_runner)
@@ -726,7 +747,10 @@ def run_gui():
             py_entry.pack(side="left", padx=(4, 10))
 
             def choose_python():
-                path = filedialog.askopenfilename(title="Choose Python executable")
+                kw = {}
+                if os.name == "nt":
+                    kw["filetypes"] = [("Python executable", "python*.exe"), ("Executables", "*.exe"), ("All files", "*.*")]
+                path = filedialog.askopenfilename(title="Choose Python executable", **kw)
                 if path:
                     self.python_var.set(path)
             ttk.Button(bar, text="Find…", command=choose_python).pack(side="left", padx=(0, 12))
@@ -848,8 +872,22 @@ if __name__ == "__main__":
     known, rest = parse_top_level(sys.argv[1:])
     if known.gui or not rest:
         # GUI mode if --gui OR if no other args given
-        ensure_awatch()  # ensure dependency
-        run_gui()
+        try:
+            run_gui()
+        except Exception as e:
+            # Surface errors instead of a silent close on double-click
+            if os.name == "nt":
+                try:
+                    import ctypes, traceback
+                    ctypes.windll.user32.MessageBoxW(
+                        0,
+                        f"{traceback.format_exc()}",
+                        "WatchGCG – startup error",
+                        0x00000010,  # MB_ICONHAND
+                    )
+                except Exception:
+                    pass
+            raise
     else:
         cli = build_cli_parser().parse_args(rest)
         

--- a/watch_gcg.py
+++ b/watch_gcg.py
@@ -42,7 +42,10 @@ def ensure_awatch(log_fn=None, upgrade_tools=False):
 
     _log("Installing 'watchfiles' …")
     try:
-        subprocess.check_call([py, "-m", "pip", "install", "watchfiles"])
+        args = [py, "-m", "pip", "install", "watchfiles"]
+        if os.name == "nt":
+            args.insert(3, "--user")  
+        subprocess.check_call(args)
     except subprocess.CalledProcessError:
         _log(f"Error: Failed to install 'watchfiles'. Try: {py} -m pip install watchfiles")
         raise


### PR DESCRIPTION
Issue #1 double-clicking ``watch_gcg.py`` was creating a transient console
    - ensures errors surface instead of silent close
    - removes ``ensure_awatch()`` pre-call in ``__main__``
    - adds --user flag just in case no admin rights for ``pip install``
    
Issue #2 users could put non-python executables in the Python interpreter field
    - validates the interpreter path before launching
    - makes Find button only show executables
    - adds fallback to safe default when field is wrong (sys.executable or "py")
    - updates README